### PR TITLE
Fixed #1 - Invalid Read on Exit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+*.txt
+.vscode/
+build/**
+valgrind_command
+

--- a/src/graphnode.cpp
+++ b/src/graphnode.cpp
@@ -10,8 +10,13 @@ GraphNode::~GraphNode()
 {
     //// STUDENT CODE
     ////
+    
+    /*
+     * The GraphNode does not get paid enough 
+     * to decide when the chat bot gets deleted. 
+     */
 
-    delete _chatBot; 
+    //// delete _chatBot; 
 
     ////
     //// EOF STUDENT CODE


### PR DESCRIPTION
Duplicate calls to `delete *_callbot`. Removed instance within GraphNode.