### PR TITLE
Solution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.vscode/
+build/

--- a/src/chatbot.cpp
+++ b/src/chatbot.cpp
@@ -45,51 +45,61 @@ ChatBot::~ChatBot()
 ChatBot::ChatBot(const ChatBot& source) {
     std::cout << "ChatBot Copy Constructor" << std::endl;
     if (this != &source) {
-        if (source._image != nullptr) {
+        if (source._image != NULL) {
             _image = new wxBitmap(*source._image);
         }
-        if (source._chatLogic != nullptr) {
-            _chatLogic = source._chatLogic;
-        }
-        if (source._rootNode != nullptr) {
-            _rootNode = source._rootNode;
-        }
+        _chatLogic = source._chatLogic;
+        _rootNode = source._rootNode;
+        _currentNode = source._currentNode;
     }
 }
 
-ChatBot::ChatBot(const ChatBot&& source) {
+ChatBot::ChatBot(ChatBot&& source) {
     std::cout << "ChatBot Move Constructor" << std::endl;
     if (this != &source) {
         _image = source._image;
+        source._image = nullptr;
+
         _chatLogic = source._chatLogic;
+        _chatLogic->SetChatbotHandle(this);
+        source._chatLogic = nullptr;
+
         _rootNode = source._rootNode;
-        delete &source;
+        source._rootNode = nullptr;
+
+        _currentNode = source._currentNode;
+        source._currentNode = nullptr;
     }
 }
 
 ChatBot& ChatBot::operator=(const ChatBot& source) {
     std::cout << "ChatBot Copy Assignment Operator" << std::endl;
     if (this != &source) {
-        if (source._image != nullptr) {
+        if (source._image != NULL) {
             _image = new wxBitmap(*source._image);
         }
-        if (source._chatLogic != nullptr) {
-            _chatLogic = source._chatLogic;
-        }
-        if (source._rootNode != nullptr) {
-            _rootNode = source._rootNode;
-        }
+        _chatLogic = source._chatLogic;
+        _rootNode = source._rootNode;
+        _currentNode = source._currentNode;
     }
     return *this;
 }
 
-ChatBot& ChatBot::operator=(const ChatBot&& source) {
+ChatBot& ChatBot::operator=(ChatBot&& source) {
     std::cout << "ChatBot Move Assignment Operator" << std::endl;
     if (this != &source) {
         _image = source._image;
+        source._image = nullptr;
+
         _chatLogic = source._chatLogic;
+        _chatLogic->SetChatbotHandle(this);
+        source._chatLogic = nullptr;
+
         _rootNode = source._rootNode;
-        delete &source;
+        source._rootNode = nullptr;
+
+        _currentNode = source._currentNode;
+        source._currentNode = nullptr;
     }
     return *this;
 }
@@ -102,10 +112,10 @@ void ChatBot::ReceiveMessageFromUser(std::string message)
 
     for (size_t i = 0; i < _currentNode->GetNumberOfChildEdges(); ++i)
     {
-        const std::unique_ptr<GraphEdge>& edge = _currentNode->GetChildEdgeAtIndex(i);
+        GraphEdge *edge = _currentNode->GetChildEdgeAtIndex(i);
         for (auto keyword : edge->GetKeywords())
         {
-            EdgeDist ed{edge.get(), ComputeLevenshteinDistance(keyword, message)};
+            EdgeDist ed{edge, ComputeLevenshteinDistance(keyword, message)};
             levDists.push_back(ed);
         }
     }

--- a/src/chatbot.cpp
+++ b/src/chatbot.cpp
@@ -42,11 +42,57 @@ ChatBot::~ChatBot()
     }
 }
 
-//// STUDENT CODE
-////
+ChatBot::ChatBot(const ChatBot& source) {
+    std::cout << "ChatBot Copy Constructor" << std::endl;
+    if (this != &source) {
+        if (source._image != nullptr) {
+            _image = new wxBitmap(*source._image);
+        }
+        if (source._chatLogic != nullptr) {
+            _chatLogic = source._chatLogic;
+        }
+        if (source._rootNode != nullptr) {
+            _rootNode = source._rootNode;
+        }
+    }
+}
 
-////
-//// EOF STUDENT CODE
+ChatBot::ChatBot(const ChatBot&& source) {
+    std::cout << "ChatBot Move Constructor" << std::endl;
+    if (this != &source) {
+        _image = source._image;
+        _chatLogic = source._chatLogic;
+        _rootNode = source._rootNode;
+        delete &source;
+    }
+}
+
+ChatBot& ChatBot::operator=(const ChatBot& source) {
+    std::cout << "ChatBot Copy Assignment Operator" << std::endl;
+    if (this != &source) {
+        if (source._image != nullptr) {
+            _image = new wxBitmap(*source._image);
+        }
+        if (source._chatLogic != nullptr) {
+            _chatLogic = source._chatLogic;
+        }
+        if (source._rootNode != nullptr) {
+            _rootNode = source._rootNode;
+        }
+    }
+    return *this;
+}
+
+ChatBot& ChatBot::operator=(const ChatBot&& source) {
+    std::cout << "ChatBot Move Assignment Operator" << std::endl;
+    if (this != &source) {
+        _image = source._image;
+        _chatLogic = source._chatLogic;
+        _rootNode = source._rootNode;
+        delete &source;
+    }
+    return *this;
+}
 
 void ChatBot::ReceiveMessageFromUser(std::string message)
 {

--- a/src/chatbot.cpp
+++ b/src/chatbot.cpp
@@ -102,10 +102,10 @@ void ChatBot::ReceiveMessageFromUser(std::string message)
 
     for (size_t i = 0; i < _currentNode->GetNumberOfChildEdges(); ++i)
     {
-        GraphEdge *edge = _currentNode->GetChildEdgeAtIndex(i);
+        const std::unique_ptr<GraphEdge>& edge = _currentNode->GetChildEdgeAtIndex(i);
         for (auto keyword : edge->GetKeywords())
         {
-            EdgeDist ed{edge, ComputeLevenshteinDistance(keyword, message)};
+            EdgeDist ed{edge.get(), ComputeLevenshteinDistance(keyword, message)};
             levDists.push_back(ed);
         }
     }

--- a/src/chatbot.h
+++ b/src/chatbot.h
@@ -27,9 +27,9 @@ public:
     ChatBot(std::string filename); // constructor WITH memory allocation
     ~ChatBot();
     ChatBot(const ChatBot& source);
-    ChatBot(const ChatBot&& source);
+    ChatBot(ChatBot&& source);
     ChatBot& operator=(const ChatBot& source);
-    ChatBot& operator=(const ChatBot&& source);
+    ChatBot& operator=(ChatBot&& source);
 
     // getters / setters
     void SetCurrentNode(GraphNode *node);

--- a/src/chatbot.h
+++ b/src/chatbot.h
@@ -26,12 +26,10 @@ public:
     ChatBot();                     // constructor WITHOUT memory allocation
     ChatBot(std::string filename); // constructor WITH memory allocation
     ~ChatBot();
-
-    //// STUDENT CODE
-    ////
-
-    ////
-    //// EOF STUDENT CODE
+    ChatBot(const ChatBot& source);
+    ChatBot(const ChatBot&& source);
+    ChatBot& operator=(const ChatBot& source);
+    ChatBot& operator=(const ChatBot&& source);
 
     // getters / setters
     void SetCurrentNode(GraphNode *node);

--- a/src/chatgui.cpp
+++ b/src/chatgui.cpp
@@ -2,6 +2,7 @@
 #include <wx/colour.h>
 #include <wx/image.h>
 #include <string>
+#include <memory>
 #include "chatbot.h"
 #include "chatlogic.h"
 #include "chatgui.h"
@@ -114,31 +115,18 @@ ChatBotPanelDialog::ChatBotPanelDialog(wxWindow *parent, wxWindowID id)
     // allow for PNG images to be handled
     wxInitAllImageHandlers();
 
-    //// STUDENT CODE
-    ////
-
     // create chat logic instance
-    _chatLogic = new ChatLogic(); 
+    _chatLogic = std::make_unique<ChatLogic>();
 
     // pass pointer to chatbot dialog so answers can be displayed in GUI
     _chatLogic->SetPanelDialogHandle(this);
 
     // load answer graph from file
     _chatLogic->LoadAnswerGraphFromFile(dataPath + "src/answergraph.txt");
-
-    ////
-    //// EOF STUDENT CODE
 }
 
 ChatBotPanelDialog::~ChatBotPanelDialog()
 {
-    //// STUDENT CODE
-    ////
-
-    delete _chatLogic;
-
-    ////
-    //// EOF STUDENT CODE
 }
 
 void ChatBotPanelDialog::AddDialogItem(wxString text, bool isFromUser)

--- a/src/chatgui.h
+++ b/src/chatgui.h
@@ -1,6 +1,8 @@
 #ifndef CHATGUI_H_
 #define CHATGUI_H_
 
+#include <memory>
+
 #include <wx/wx.h>
 
 class ChatLogic; // forward declaration
@@ -13,13 +15,7 @@ private:
     wxBoxSizer *_dialogSizer;
     wxBitmap _image;
 
-    //// STUDENT CODE
-    ////
-
-    ChatLogic *_chatLogic;
-
-    ////
-    //// EOF STUDENT CODE
+    std::unique_ptr<ChatLogic> _chatLogic;
 
 public:
     // constructor / destructor
@@ -27,7 +23,7 @@ public:
     ~ChatBotPanelDialog();
 
     // getter / setter
-    ChatLogic *GetChatLogicHandle() { return _chatLogic; }
+    std::unique_ptr<ChatLogic>& GetChatLogicHandle() { return _chatLogic; }
 
     // events
     void paintEvent(wxPaintEvent &evt);

--- a/src/chatlogic.cpp
+++ b/src/chatlogic.cpp
@@ -137,14 +137,12 @@ void ChatLogic::LoadAnswerGraphFromFile(std::string filename)
                             edge->SetChildNode((*childNode).get());
                             edge->SetParentNode((*parentNode).get());
 
-                            _edges.push_back(std::move(edge));
-
                             // find all keywords for current node
-                            AddAllTokensToElement("KEYWORD", tokens, *(_edges.back()));
+                            AddAllTokensToElement("KEYWORD", tokens, *edge);
 
                             // store reference in child node and parent node
-                            (*childNode)->AddEdgeToParentNode(_edges.back().get());
-                            (*parentNode)->AddEdgeToChildNode(_edges.back().get());
+                            (*childNode)->AddEdgeToParentNode(edge.get());
+                            (*parentNode)->AddEdgeToChildNode(std::move(edge));
                         }
                     }
                 }

--- a/src/chatlogic.cpp
+++ b/src/chatlogic.cpp
@@ -11,26 +11,12 @@
 #include "chatbot.h"
 #include "chatlogic.h"
 
-
 ChatLogic::ChatLogic()
 {
-    //// STUDENT CODE
-    ////
-
-    // create instance of chatbot
-    _chatBot = new ChatBot("../images/chatbot.png");
-
-    // add pointer to chatlogic so that chatbot answers can be passed on to the GUI
-    _chatBot->SetChatLogicHandle(this);
-
-    ////
-    //// EOF STUDENT CODE
 }
 
 ChatLogic::~ChatLogic()
 {
-    // delete chatbot instance
-    delete _chatBot;
 }
 
 template <typename T>
@@ -181,9 +167,12 @@ void ChatLogic::LoadAnswerGraphFromFile(std::string filename)
         }
     }
 
+    ChatBot chatBot("../images/chatbot.png");
+    chatBot.SetChatLogicHandle(this);
+    chatBot.SetRootNode(rootNode);
+
     // add chatbot to graph root node
-    _chatBot->SetRootNode(rootNode);
-    rootNode->MoveChatbotHere(_chatBot);
+    rootNode->MoveChatbotHere(std::move(chatBot));
 
 }
 
@@ -192,9 +181,9 @@ void ChatLogic::SetPanelDialogHandle(ChatBotPanelDialog *panelDialog)
     _panelDialog = panelDialog;
 }
 
-void ChatLogic::SetChatbotHandle(ChatBot *chatbot)
+void ChatLogic::SetChatbotHandle(ChatBot *chatBot)
 {
-    _chatBot = chatbot;
+    _chatBot = chatBot;
 }
 
 void ChatLogic::SendMessageToChatbot(std::string message)

--- a/src/chatlogic.h
+++ b/src/chatlogic.h
@@ -5,9 +5,9 @@
 #include <vector>
 #include <string>
 #include "chatgui.h"
+#include "chatbot.h"
 
 // forward declarations
-class ChatBot;
 class GraphEdge;
 class GraphNode;
 

--- a/src/chatlogic.h
+++ b/src/chatlogic.h
@@ -1,6 +1,7 @@
 #ifndef CHATLOGIC_H_
 #define CHATLOGIC_H_
 
+#include <memory>
 #include <vector>
 #include <string>
 #include "chatgui.h"
@@ -17,8 +18,8 @@ private:
     ////
 
     // data handles (owned)
-    std::vector<GraphNode *> _nodes;
-    std::vector<GraphEdge *> _edges;
+    std::vector<std::unique_ptr<GraphNode>> _nodes;
+    std::vector<std::unique_ptr<GraphEdge>> _edges;
 
     ////
     //// EOF STUDENT CODE

--- a/src/chatlogic.h
+++ b/src/chatlogic.h
@@ -14,15 +14,8 @@ class GraphNode;
 class ChatLogic
 {
 private:
-    //// STUDENT CODE
-    ////
-
     // data handles (owned)
     std::vector<std::unique_ptr<GraphNode>> _nodes;
-    std::vector<std::unique_ptr<GraphEdge>> _edges;
-
-    ////
-    //// EOF STUDENT CODE
 
     // data handles (not owned)
     GraphNode *_currentNode;

--- a/src/graphnode.cpp
+++ b/src/graphnode.cpp
@@ -8,13 +8,6 @@ GraphNode::GraphNode(int id)
 
 GraphNode::~GraphNode()
 {
-    //// STUDENT CODE
-    ////
-
-    delete _chatBot; 
-
-    ////
-    //// EOF STUDENT CODE
 }
 
 void GraphNode::AddToken(std::string token)

--- a/src/graphnode.cpp
+++ b/src/graphnode.cpp
@@ -20,9 +20,9 @@ void GraphNode::AddEdgeToParentNode(GraphEdge *edge)
     _parentEdges.push_back(edge);
 }
 
-void GraphNode::AddEdgeToChildNode(GraphEdge *edge)
+void GraphNode::AddEdgeToChildNode(std::unique_ptr<GraphEdge> edge)
 {
-    _childEdges.push_back(edge);
+    _childEdges.push_back(std::move(edge));
 }
 
 //// STUDENT CODE
@@ -41,13 +41,7 @@ void GraphNode::MoveChatbotToNewNode(GraphNode *newNode)
 ////
 //// EOF STUDENT CODE
 
-GraphEdge *GraphNode::GetChildEdgeAtIndex(int index)
+const std::unique_ptr<GraphEdge>& GraphNode::GetChildEdgeAtIndex(int index)
 {
-    //// STUDENT CODE
-    ////
-
     return _childEdges[index];
-
-    ////
-    //// EOF STUDENT CODE
 }

--- a/src/graphnode.cpp
+++ b/src/graphnode.cpp
@@ -25,23 +25,18 @@ void GraphNode::AddEdgeToChildNode(std::unique_ptr<GraphEdge> edge)
     _childEdges.push_back(std::move(edge));
 }
 
-//// STUDENT CODE
-////
-void GraphNode::MoveChatbotHere(ChatBot *chatbot)
+void GraphNode::MoveChatbotHere(ChatBot&& chatBot)
 {
-    _chatBot = chatbot;
-    _chatBot->SetCurrentNode(this);
+    _chatBot = std::move(chatBot);
+    _chatBot.SetCurrentNode(this);
 }
 
 void GraphNode::MoveChatbotToNewNode(GraphNode *newNode)
 {
-    newNode->MoveChatbotHere(_chatBot);
-    _chatBot = nullptr; // invalidate pointer at source
+    newNode->MoveChatbotHere(std::move(_chatBot));
 }
-////
-//// EOF STUDENT CODE
 
-const std::unique_ptr<GraphEdge>& GraphNode::GetChildEdgeAtIndex(int index)
+GraphEdge* GraphNode::GetChildEdgeAtIndex(int index)
 {
-    return _childEdges[index];
+    return _childEdges[index].get();
 }

--- a/src/graphnode.h
+++ b/src/graphnode.h
@@ -17,7 +17,7 @@ private:
 
     // data handles (not owned)
     std::vector<GraphEdge *> _parentEdges; // edges to preceding nodes 
-    ChatBot *_chatBot;
+    ChatBot _chatBot;
 
     // proprietary members
     int _id;
@@ -31,7 +31,7 @@ public:
     // getter / setter
     int GetID() { return _id; }
     int GetNumberOfChildEdges() { return _childEdges.size(); }
-    const std::unique_ptr<GraphEdge>& GetChildEdgeAtIndex(int index);
+    GraphEdge* GetChildEdgeAtIndex(int index);
     std::vector<std::string> GetAnswers() { return _answers; }
     int GetNumberOfParents() { return _parentEdges.size(); }
 
@@ -40,14 +40,7 @@ public:
     void AddEdgeToParentNode(GraphEdge *edge);
     void AddEdgeToChildNode(std::unique_ptr<GraphEdge> edge);
 
-    //// STUDENT CODE
-    ////
-
-    void MoveChatbotHere(ChatBot *chatbot);
-
-    ////
-    //// EOF STUDENT CODE
-
+    void MoveChatbotHere(ChatBot&& chatBot);
     void MoveChatbotToNewNode(GraphNode *newNode);
 };
 

--- a/src/graphnode.h
+++ b/src/graphnode.h
@@ -1,10 +1,10 @@
 #ifndef GRAPHNODE_H_
 #define GRAPHNODE_H_
 
+#include <memory>
 #include <vector>
 #include <string>
 #include "chatbot.h"
-
 
 // forward declarations
 class GraphEdge;
@@ -12,18 +12,12 @@ class GraphEdge;
 class GraphNode
 {
 private:
-    //// STUDENT CODE
-    ////
-
     // data handles (owned)
-    std::vector<GraphEdge *> _childEdges;  // edges to subsequent nodes
+    std::vector<std::unique_ptr<GraphEdge>> _childEdges;  // edges to subsequent nodes
 
     // data handles (not owned)
     std::vector<GraphEdge *> _parentEdges; // edges to preceding nodes 
     ChatBot *_chatBot;
-
-    ////
-    //// EOF STUDENT CODE
 
     // proprietary members
     int _id;
@@ -37,14 +31,14 @@ public:
     // getter / setter
     int GetID() { return _id; }
     int GetNumberOfChildEdges() { return _childEdges.size(); }
-    GraphEdge *GetChildEdgeAtIndex(int index);
+    const std::unique_ptr<GraphEdge>& GetChildEdgeAtIndex(int index);
     std::vector<std::string> GetAnswers() { return _answers; }
     int GetNumberOfParents() { return _parentEdges.size(); }
 
     // proprietary functions
     void AddToken(std::string token); // add answers to list
     void AddEdgeToParentNode(GraphEdge *edge);
-    void AddEdgeToChildNode(GraphEdge *edge);
+    void AddEdgeToChildNode(std::unique_ptr<GraphEdge> edge);
 
     //// STUDENT CODE
     ////


### PR DESCRIPTION
### Quality of Code

- [x] The code compiles and runs with `cmake` and `make`.

### Task 1: Exclusive Ownership 1

Addressed in commit https://github.com/udacity/CppND-Memory-Management-Chatbot/commit/e0e7409e5d21d0e8eb449525274b76dcc2049b57

- [x] In file `chatgui.h` / `chatgui.cpp`, `_chatLogic` is made an exclusive resource to class `ChatbotPanelDialog` using an appropriate smart pointer. Where required, changes are made to the code such that data structures and function parameters reflect the new structure.

### Task 2: The Rule of Five

Addressed in commit https://github.com/udacity/CppND-Memory-Management-Chatbot/commit/fd1c47e08a702d60177ac89495f0546b9d8ec8bb

- [x] In file `chatbot.h` / `chatbot.cpp`, changes are made to the class `ChatBot` such that it complies with the Rule of Five. Memory resources are properly allocated / deallocated on the heap and member data is copied where it makes sense. In each of the methods (e.g. the copy constructor), a string of the type "ChatBot Copy Constructor" is printed to the console so that it is possible to see which method is called in later examples.

### Task 3: Exclusive Ownership 2

Addressed in commit https://github.com/udacity/CppND-Memory-Management-Chatbot/commit/7f0769ed7d24b02629e649acbf55ac835ae1dcea

- [x] In file `chatlogic.h` / `chatlogic.cpp`, the vector `_nodes` are adapted in a way that the instances of GraphNodes to which the vector elements refer are exclusively owned by the class ChatLogic. An appropriate type of smart pointer is used to achieve this.
- [x] When passing the `GraphNode` instances to functions, ownership is not transferred.

### Task 4: Moving Smart Pointers

Addressed in commit https://github.com/udacity/CppND-Memory-Management-Chatbot/commit/9a0459ed120d7fc86c2164a33863f792ea7e8cb9

- [x] In files `chatlogic.h` / `chatlogic.cpp` and `graphnodes.h` / `graphnodes.cpp` all instances of `GraphEdge` are changed in a way such that each instance of `GraphNode` exclusively owns the outgoing `GraphEdge`s and holds non-owning references to incoming `GraphEdge`s. Appropriate smart pointers are used to do this. Where required, changes are made to the code such that data structures and function parameters reflect the changes.
- [x] In files `chatlogic.h` / `chatlogic.cpp` and `graphnodes.h` / `graphnodes.cpp`, move semantics are used when transferring ownership from class `ChatLogic`, where all instances of `GraphEdge` are created, into instances of `GraphNode`.

### Task 5: Moving the ChatBot

Addressed in commit https://github.com/udacity/CppND-Memory-Management-Chatbot/commit/9ec47388b19dde88c316ca35a73da32187072655

- [x] In file `chatlogic.cpp`, a local `ChatBot` instance is created on the stack at the bottom of function `LoadAnswerGraphFromFile` and move semantics are used to pass the `ChatBot` instance into the root node.
- [x] `ChatLogic` has no ownership relation to the `ChatBot` instance and thus is no longer responsible for memory allocation and deallocation.
- [x] `ChatLogic` has no ownership relation to the `ChatBot` instance and thus is no longer responsible for memory allocation and deallocation.