### PR TITLE
Fix libwxgtk3.0 apt dependencies for Ubuntu 20.04 focal

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Your goal is to use the course knowledge to optimize the ChatBot program from a 
   * Mac: same deal as make - [install Xcode command line tools](https://developer.apple.com/xcode/features/)
   * Windows: recommend using [MinGW](http://www.mingw.org/)
 * wxWidgets >= 3.0
-  * Linux: `sudo apt-get install libwxgtk3.0-dev libwxgtk3.0-0v5`. If you are facing unmet dependency issues, refer to the [official page](https://wiki.codelite.org/pmwiki.php/Main/WxWidgets30Binaries#toc2) for installing the unmet dependencies.
+  * Linux: `sudo apt-get install libwxgtk3.0-gtk3-dev libwxgtk3.0-gtk3-0v5`. If you are facing unmet dependency issues, refer to the [official page](https://wiki.codelite.org/pmwiki.php/Main/WxWidgets30Binaries#toc2) for installing the unmet dependencies.
   * Mac: There is a [homebrew installation available](https://formulae.brew.sh/formula/wxmac).
   * Installation instructions can be found [here](https://wiki.wxwidgets.org/Install). Some version numbers may need to be changed in instructions to install v3.0 or greater.
 


### PR DESCRIPTION
[libwxgtk3.0-dev](https://packages.ubuntu.com/search?suite=default&section=all&arch=any&keywords=libwxgtk3.0-dev&searchon=names) and [libwxgtk3.0-0v5](https://packages.ubuntu.com/search?suite=default&section=all&arch=any&keywords=libwxgtk3.0-0v5&searchon=names) are only available on Ubuntu 18.04. 

The updated versions, [libwxgtk3.0-gtk3-dev](https://packages.ubuntu.com/search?suite=default&section=all&arch=any&keywords=libwxgtk3.0-gtk3-dev&searchon=names) and  [libwxgtk3.0-gtk3-0v5](https://packages.ubuntu.com/search?suite=default&section=all&arch=any&keywords=libwxgtk3.0-gtk3-0v5&searchon=names) remain compatible with 18.04 but also support all newer Ubuntu versions up to 21.10. Apart from that, the pacakges are identical (AFAIK).