### PR TITLE
fix for wxwidget related paths for macos

### DIFF
--- a/src/chatgui.cpp
+++ b/src/chatgui.cpp
@@ -1,10 +1,14 @@
+#include <string>
+
 #include <wx/filename.h>
 #include <wx/colour.h>
 #include <wx/image.h>
-#include <string>
+
 #include "chatbot.h"
 #include "chatlogic.h"
 #include "chatgui.h"
+#include "pathutils.h"
+
 
 // size of chatbot window
 const int width = 414;
@@ -12,9 +16,6 @@ const int height = 736;
 
 // wxWidgets APP
 IMPLEMENT_APP(ChatBotApp);
-
-std::string dataPath = "../";
-std::string imgBasePath = dataPath + "images/";
 
 bool ChatBotApp::OnInit()
 {
@@ -88,7 +89,7 @@ void ChatBotFrameImagePanel::paintNow()
 void ChatBotFrameImagePanel::render(wxDC &dc)
 {
     // load backgroud image from file
-    wxString imgFile = imgBasePath + "sf_bridge.jpg";
+    wxString imgFile = GetImagesBasePath() + "sf_bridge.jpg";
     wxImage image;
     image.LoadFile(imgFile);
 
@@ -124,7 +125,7 @@ ChatBotPanelDialog::ChatBotPanelDialog(wxWindow *parent, wxWindowID id)
     _chatLogic->SetPanelDialogHandle(this);
 
     // load answer graph from file
-    _chatLogic->LoadAnswerGraphFromFile(dataPath + "src/answergraph.txt");
+    _chatLogic->LoadAnswerGraphFromFile(GetDataPath() + "src/answergraph.txt");
 
     ////
     //// EOF STUDENT CODE
@@ -182,7 +183,7 @@ void ChatBotPanelDialog::paintNow()
 void ChatBotPanelDialog::render(wxDC &dc)
 {
     wxImage image;
-    image.LoadFile(imgBasePath + "sf_bridge_inner.jpg");
+    image.LoadFile(GetImagesBasePath() + "sf_bridge_inner.jpg");
 
     wxSize sz = this->GetSize();
     wxImage imgSmall = image.Rescale(sz.GetWidth(), sz.GetHeight(), wxIMAGE_QUALITY_HIGH);
@@ -198,7 +199,7 @@ ChatBotPanelDialogItem::ChatBotPanelDialogItem(wxPanel *parent, wxString text, b
     wxBitmap *bitmap = isFromUser == true ? nullptr : ((ChatBotPanelDialog*)parent)->GetChatLogicHandle()->GetImageFromChatbot(); 
 
     // create image and text
-    _chatBotImg = new wxStaticBitmap(this, wxID_ANY, (isFromUser ? wxBitmap(imgBasePath + "user.png", wxBITMAP_TYPE_PNG) : *bitmap), wxPoint(-1, -1), wxSize(-1, -1));
+    _chatBotImg = new wxStaticBitmap(this, wxID_ANY, (isFromUser ? wxBitmap(GetImagesBasePath() + "user.png", wxBITMAP_TYPE_PNG) : *bitmap), wxPoint(-1, -1), wxSize(-1, -1));
     _chatBotTxt = new wxStaticText(this, wxID_ANY, text, wxPoint(-1, -1), wxSize(150, -1), wxALIGN_CENTRE | wxBORDER_NONE);
     _chatBotTxt->SetForegroundColour(isFromUser == true ? wxColor(*wxBLACK) : wxColor(*wxWHITE));
 

--- a/src/chatlogic.cpp
+++ b/src/chatlogic.cpp
@@ -10,7 +10,7 @@
 #include "graphnode.h"
 #include "chatbot.h"
 #include "chatlogic.h"
-
+#include "pathutils.h"
 
 ChatLogic::ChatLogic()
 {
@@ -18,7 +18,7 @@ ChatLogic::ChatLogic()
     ////
 
     // create instance of chatbot
-    _chatBot = new ChatBot("../images/chatbot.png");
+    _chatBot = new ChatBot(GetImagesBasePath() + "chatbot.png");
 
     // add pointer to chatlogic so that chatbot answers can be passed on to the GUI
     _chatBot->SetChatLogicHandle(this);
@@ -218,7 +218,7 @@ void ChatLogic::LoadAnswerGraphFromFile(std::string filename)
     // add chatbot to graph root node
     _chatBot->SetRootNode(rootNode);
     rootNode->MoveChatbotHere(_chatBot);
-    
+
     ////
     //// EOF STUDENT CODE
 }

--- a/src/pathutils.cpp
+++ b/src/pathutils.cpp
@@ -1,0 +1,58 @@
+#include <string>
+#include <memory>
+
+#include <wx/stdpaths.h>
+#include <wx/filename.h>
+
+
+namespace
+{
+    static std::string executableDir{};
+    static std::string dataDir{};
+    static std::string imagesBaseDir{};
+
+    std::string GetParentDirIfExists(const std::string& dir, const std::string& fallBackDir)
+    {
+        auto lastSeparator = dir.find_last_of(wxFileName::GetPathSeparator());
+
+        if (lastSeparator != std::string::npos)
+        {
+            return dir.substr(0, lastSeparator);
+        }
+
+        return fallBackDir;
+    }
+
+    std::string GetExecutableDir()
+    {
+        if (executableDir.empty())
+        {
+            auto executablePath = wxStandardPaths::Get().GetExecutablePath();
+            auto pathStr = executablePath.ToStdString();
+
+            executableDir = GetParentDirIfExists(pathStr, wxGetCwd().ToStdString());
+        }
+
+        return executableDir;
+    }
+};
+
+std::string GetDataPath()
+{
+    if (dataDir.empty())
+    {
+        dataDir = GetParentDirIfExists(GetExecutableDir(), GetExecutableDir()) + wxFileName::GetPathSeparator();
+    }
+
+    return dataDir;
+}
+
+std::string GetImagesBasePath()
+{
+    if (imagesBaseDir.empty())
+    {
+        imagesBaseDir = GetDataPath() + "images/";
+    }
+
+    return imagesBaseDir;
+}

--- a/src/pathutils.h
+++ b/src/pathutils.h
@@ -1,0 +1,5 @@
+#include <string>
+
+
+std::string GetDataPath();
+std::string GetImagesBasePath();


### PR DESCRIPTION
added pathutils unit, it povides correct paths to "data" and "images" dirs relatively to executable.